### PR TITLE
Stop disabling buffering by default

### DIFF
--- a/includes/nginx.conf
+++ b/includes/nginx.conf
@@ -22,7 +22,7 @@ server {
 
     location / {
         proxy_pass                              http://localhost:8080/;
-        proxy_buffering                         off;
+#        proxy_buffering                         off;  # openHAB supports non-buffering specifically for SSEs now
         proxy_set_header Host                   $http_host;
         proxy_set_header X-Real-IP              $remote_addr;
         proxy_set_header X-Forwarded-For        $proxy_add_x_forwarded_for;


### PR DESCRIPTION
Eclipse/Smarthome has just implemented the change to SSE headers which means we don't need to turn off proxy_buffering.

In testing, responses were only slightly faster using RPi 3 with this change.

This shouldn't effect the bash script because no line has moved and the uncomment/comment functions do not touch 25.